### PR TITLE
Milestone A: WPF .NET 8 shell app with Frame navigation and MVVM placeholders

### DIFF
--- a/StockKLineApp.sln
+++ b/StockKLineApp.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StockKLineApp", "src\StockKLineApp\StockKLineApp.csproj", "{A4EF90D8-5FB0-4618-8C44-44C876F24D51}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A4EF90D8-5FB0-4618-8C44-44C876F24D51}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A4EF90D8-5FB0-4618-8C44-44C876F24D51}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A4EF90D8-5FB0-4618-8C44-44C876F24D51}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A4EF90D8-5FB0-4618-8C44-44C876F24D51}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/src/StockKLineApp/App.xaml
+++ b/src/StockKLineApp/App.xaml
@@ -1,0 +1,6 @@
+<Application x:Class="StockKLineApp.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/src/StockKLineApp/App.xaml.cs
+++ b/src/StockKLineApp/App.xaml.cs
@@ -1,0 +1,36 @@
+using System.Windows;
+using Microsoft.Extensions.DependencyInjection;
+using StockKLineApp.Services;
+using StockKLineApp.ViewModels;
+using StockKLineApp.Views;
+
+namespace StockKLineApp;
+
+public partial class App : Application
+{
+    public static ServiceProvider Services { get; private set; } = null!;
+
+    protected override void OnStartup(StartupEventArgs e)
+    {
+        base.OnStartup(e);
+
+        var serviceCollection = new ServiceCollection();
+        ConfigureServices(serviceCollection);
+        Services = serviceCollection.BuildServiceProvider();
+
+        var mainWindow = Services.GetRequiredService<MainWindow>();
+        mainWindow.Show();
+    }
+
+    private static void ConfigureServices(IServiceCollection services)
+    {
+        services.AddSingleton<INavigationService, FrameNavigationService>();
+
+        services.AddSingleton<MainWindow>();
+        services.AddSingleton<MainWindowViewModel>();
+        services.AddSingleton<MainPage>();
+        services.AddSingleton<MainPageViewModel>();
+        services.AddSingleton<StockDetailPage>();
+        services.AddSingleton<StockDetailPageViewModel>();
+    }
+}

--- a/src/StockKLineApp/MainWindow.xaml
+++ b/src/StockKLineApp/MainWindow.xaml
@@ -1,0 +1,9 @@
+<Window x:Class="StockKLineApp.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Stock KLine App" Height="720" Width="1200">
+    <Grid>
+        <Frame x:Name="RootFrame"
+               NavigationUIVisibility="Hidden" />
+    </Grid>
+</Window>

--- a/src/StockKLineApp/MainWindow.xaml.cs
+++ b/src/StockKLineApp/MainWindow.xaml.cs
@@ -1,0 +1,21 @@
+using System.Windows;
+using StockKLineApp.Services;
+using StockKLineApp.ViewModels;
+using StockKLineApp.Views;
+
+namespace StockKLineApp;
+
+public partial class MainWindow : Window
+{
+    public MainWindow(
+        MainWindowViewModel viewModel,
+        INavigationService navigationService,
+        MainPage mainPage)
+    {
+        InitializeComponent();
+
+        DataContext = viewModel;
+        navigationService.Initialize(RootFrame);
+        navigationService.Navigate(mainPage);
+    }
+}

--- a/src/StockKLineApp/Models/StockSummary.cs
+++ b/src/StockKLineApp/Models/StockSummary.cs
@@ -1,0 +1,10 @@
+namespace StockKLineApp.Models;
+
+public class StockSummary
+{
+    public required string Symbol { get; init; }
+
+    public required string Name { get; init; }
+
+    public override string ToString() => $"{Symbol} - {Name}";
+}

--- a/src/StockKLineApp/Services/FrameNavigationService.cs
+++ b/src/StockKLineApp/Services/FrameNavigationService.cs
@@ -1,0 +1,28 @@
+using System.Windows.Controls;
+
+namespace StockKLineApp.Services;
+
+public class FrameNavigationService : INavigationService
+{
+    private Frame? _frame;
+
+    public bool CanGoBack => _frame?.CanGoBack ?? false;
+
+    public void Initialize(Frame frame)
+    {
+        _frame = frame;
+    }
+
+    public void Navigate(Page page)
+    {
+        _frame?.Navigate(page);
+    }
+
+    public void GoBack()
+    {
+        if (CanGoBack)
+        {
+            _frame?.GoBack();
+        }
+    }
+}

--- a/src/StockKLineApp/Services/INavigationService.cs
+++ b/src/StockKLineApp/Services/INavigationService.cs
@@ -1,0 +1,14 @@
+using System.Windows.Controls;
+
+namespace StockKLineApp.Services;
+
+public interface INavigationService
+{
+    void Initialize(Frame frame);
+
+    void Navigate(Page page);
+
+    void GoBack();
+
+    bool CanGoBack { get; }
+}

--- a/src/StockKLineApp/StockKLineApp.csproj
+++ b/src/StockKLineApp/StockKLineApp.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/StockKLineApp/ViewModels/MainPageViewModel.cs
+++ b/src/StockKLineApp/ViewModels/MainPageViewModel.cs
@@ -1,0 +1,94 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Windows.Data;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using StockKLineApp.Models;
+using StockKLineApp.Services;
+using StockKLineApp.Views;
+
+namespace StockKLineApp.ViewModels;
+
+public partial class MainPageViewModel : ObservableObject
+{
+    private readonly INavigationService _navigationService;
+    private readonly StockDetailPage _stockDetailPage;
+    private readonly StockDetailPageViewModel _stockDetailPageViewModel;
+
+    [ObservableProperty]
+    private string searchKeyword = string.Empty;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(OpenStockDetailCommand))]
+    private StockSummary? selectedStock;
+
+    public ObservableCollection<StockSummary> Stocks { get; }
+
+    public ICollectionView FilteredStocks { get; }
+
+    public MainPageViewModel(
+        INavigationService navigationService,
+        StockDetailPage stockDetailPage,
+        StockDetailPageViewModel stockDetailPageViewModel)
+    {
+        _navigationService = navigationService;
+        _stockDetailPage = stockDetailPage;
+        _stockDetailPageViewModel = stockDetailPageViewModel;
+
+        Stocks = new ObservableCollection<StockSummary>
+        {
+            new() { Symbol = "AAPL", Name = "Apple Inc." },
+            new() { Symbol = "MSFT", Name = "Microsoft Corp." },
+            new() { Symbol = "TSLA", Name = "Tesla, Inc." }
+        };
+
+        FilteredStocks = CollectionViewSource.GetDefaultView(Stocks);
+        FilteredStocks.Filter = FilterStock;
+
+        Stocks.CollectionChanged += OnStocksCollectionChanged;
+    }
+
+    [RelayCommand(CanExecute = nameof(CanOpenStockDetail))]
+    private void OpenStockDetail()
+    {
+        if (SelectedStock is null)
+        {
+            return;
+        }
+
+        _stockDetailPageViewModel.Load(SelectedStock);
+        _navigationService.Navigate(_stockDetailPage);
+    }
+
+    partial void OnSearchKeywordChanged(string value)
+    {
+        FilteredStocks.Refresh();
+    }
+
+    private bool FilterStock(object item)
+    {
+        if (item is not StockSummary stock)
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(SearchKeyword))
+        {
+            return true;
+        }
+
+        return stock.Symbol.Contains(SearchKeyword, StringComparison.OrdinalIgnoreCase)
+               || stock.Name.Contains(SearchKeyword, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private bool CanOpenStockDetail() => SelectedStock is not null;
+
+    private void OnStocksCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.Action == NotifyCollectionChangedAction.Remove && SelectedStock is not null && !Stocks.Contains(SelectedStock))
+        {
+            SelectedStock = null;
+        }
+    }
+}

--- a/src/StockKLineApp/ViewModels/MainWindowViewModel.cs
+++ b/src/StockKLineApp/ViewModels/MainWindowViewModel.cs
@@ -1,0 +1,7 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace StockKLineApp.ViewModels;
+
+public partial class MainWindowViewModel : ObservableObject
+{
+}

--- a/src/StockKLineApp/ViewModels/StockDetailPageViewModel.cs
+++ b/src/StockKLineApp/ViewModels/StockDetailPageViewModel.cs
@@ -1,0 +1,34 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using StockKLineApp.Models;
+using StockKLineApp.Services;
+
+namespace StockKLineApp.ViewModels;
+
+public partial class StockDetailPageViewModel : ObservableObject
+{
+    private readonly INavigationService _navigationService;
+
+    [ObservableProperty]
+    private string pageTitle = "股票详情占位";
+
+    [ObservableProperty]
+    private string summaryText = "请选择一支股票查看详情。";
+
+    public StockDetailPageViewModel(INavigationService navigationService)
+    {
+        _navigationService = navigationService;
+    }
+
+    public void Load(StockSummary stock)
+    {
+        PageTitle = $"{stock.Symbol} - {stock.Name}";
+        SummaryText = "这里将承载 K 线图、区间选择和统计信息。";
+    }
+
+    [RelayCommand]
+    private void GoBack()
+    {
+        _navigationService.GoBack();
+    }
+}

--- a/src/StockKLineApp/Views/MainPage.xaml
+++ b/src/StockKLineApp/Views/MainPage.xaml
@@ -1,0 +1,56 @@
+<Page x:Class="StockKLineApp.Views.MainPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d"
+      d:DesignHeight="450"
+      d:DesignWidth="800"
+      Title="MainPage">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="12" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Border Grid.Row="0" Padding="12" Background="#FFF5F5F5" CornerRadius="6">
+            <DockPanel>
+                <TextBlock DockPanel.Dock="Left"
+                           VerticalAlignment="Center"
+                           FontWeight="SemiBold"
+                           Margin="0,0,8,0"
+                           Text="搜索股票:" />
+                <TextBox Width="280"
+                         Text="{Binding SearchKeyword, UpdateSourceTrigger=PropertyChanged}" />
+            </DockPanel>
+        </Border>
+
+        <Grid Grid.Row="2">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="320" />
+                <ColumnDefinition Width="16" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <Border Grid.Column="0" BorderBrush="#FFD0D0D0" BorderThickness="1" Padding="8" CornerRadius="6">
+                <DockPanel>
+                    <TextBlock DockPanel.Dock="Top" FontWeight="SemiBold" Margin="0,0,0,8" Text="股票列表（占位）" />
+                    <Button DockPanel.Dock="Bottom" Margin="0,8,0,0" Padding="8,4" Content="查看详情"
+                            Command="{Binding OpenStockDetailCommand}" />
+                    <ListBox MouseDoubleClick="OnStockDoubleClick" ItemsSource="{Binding FilteredStocks}"
+                             SelectedItem="{Binding SelectedStock, Mode=TwoWay}"
+                             DisplayMemberPath="Symbol" />
+                </DockPanel>
+            </Border>
+
+            <Border Grid.Column="2" BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="6" Padding="16">
+                <StackPanel>
+                    <TextBlock FontSize="20" FontWeight="Bold" Text="主页面占位区域" />
+                    <TextBlock Margin="0,8,0,0" TextWrapping="Wrap"
+                               Text="本区域将在后续里程碑承载数据总览和图表入口。目前仅提供壳应用布局。" />
+                </StackPanel>
+            </Border>
+        </Grid>
+    </Grid>
+</Page>

--- a/src/StockKLineApp/Views/MainPage.xaml.cs
+++ b/src/StockKLineApp/Views/MainPage.xaml.cs
@@ -1,0 +1,25 @@
+using System.Windows.Controls;
+using System.Windows.Input;
+using StockKLineApp.ViewModels;
+
+namespace StockKLineApp.Views;
+
+public partial class MainPage : Page
+{
+    private readonly MainPageViewModel _viewModel;
+
+    public MainPage(MainPageViewModel viewModel)
+    {
+        InitializeComponent();
+        _viewModel = viewModel;
+        DataContext = viewModel;
+    }
+
+    private void OnStockDoubleClick(object sender, MouseButtonEventArgs e)
+    {
+        if (_viewModel.OpenStockDetailCommand.CanExecute(null))
+        {
+            _viewModel.OpenStockDetailCommand.Execute(null);
+        }
+    }
+}

--- a/src/StockKLineApp/Views/StockDetailPage.xaml
+++ b/src/StockKLineApp/Views/StockDetailPage.xaml
@@ -1,0 +1,40 @@
+<Page x:Class="StockKLineApp.Views.StockDetailPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d"
+      d:DesignHeight="450"
+      d:DesignWidth="800"
+      Title="StockDetailPage">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="12" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <DockPanel Grid.Row="0">
+            <Button DockPanel.Dock="Left" Content="返回" Padding="10,4" Margin="0,0,12,0"
+                    Command="{Binding GoBackCommand}" />
+            <TextBlock VerticalAlignment="Center" FontSize="22" FontWeight="Bold" Text="{Binding PageTitle}" />
+        </DockPanel>
+
+        <Border Grid.Row="2" BorderBrush="#FFD0D0D0" BorderThickness="1" CornerRadius="6" Padding="16">
+            <StackPanel>
+                <TextBlock FontSize="18" FontWeight="SemiBold" Text="股票详情页占位布局" />
+                <TextBlock Margin="0,8,0,0" Text="{Binding SummaryText}" />
+
+                <Border Margin="0,12,0,0" BorderBrush="#FFE5E5E5" BorderThickness="1" Height="180" Background="#FFF9F9F9">
+                    <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="#FF666666"
+                               Text="K 线图占位" />
+                </Border>
+
+                <Border Margin="0,12,0,0" BorderBrush="#FFE5E5E5" BorderThickness="1" Height="80" Background="#FFF9F9F9">
+                    <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="#FF666666"
+                               Text="时间范围条占位" />
+                </Border>
+            </StackPanel>
+        </Border>
+    </Grid>
+</Page>

--- a/src/StockKLineApp/Views/StockDetailPage.xaml.cs
+++ b/src/StockKLineApp/Views/StockDetailPage.xaml.cs
@@ -1,0 +1,13 @@
+using System.Windows.Controls;
+using StockKLineApp.ViewModels;
+
+namespace StockKLineApp.Views;
+
+public partial class StockDetailPage : Page
+{
+    public StockDetailPage(StockDetailPageViewModel viewModel)
+    {
+        InitializeComponent();
+        DataContext = viewModel;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a runnable WPF (.NET 8) shell that establishes the app skeleton, navigation and MVVM wiring for subsequent milestones.
- Deliver placeholder UIs for the main page and stock detail page so future work can focus on CSV import and K-line rendering without reworking navigation.

### Description
- Bootstrapped a new WPF project under `src/StockKLineApp` and added `StockKLineApp.sln` and `StockKLineApp.csproj` with `CommunityToolkit.Mvvm` and DI (`Microsoft.Extensions.DependencyInjection`).
- Implemented DI initialization in `App.xaml.cs` and registered pages and view models so the app resolves dependencies at startup.
- Added `Frame`-based navigation with an `INavigationService` interface and `FrameNavigationService` implementation, initialized in `MainWindow` which hosts the `RootFrame`.
- Implemented MVVM placeholders: `MainPage` (search box + left stock list + placeholder content) and `StockDetailPage` (title, back button, K-line and range-bar placeholders) with corresponding view models and simple sample data and navigation commands.

### Testing
- Attempted automated build with `dotnet build StockKLineApp.sln` in this environment, which failed because `dotnet` is not installed (error: `bash: command not found: dotnet`).
- Project files were added and committed into the repo (`feat: bootstrap WPF shell app with frame navigation`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69886c1762188327bc2545b787a6b5b3)