### PR TITLE
Milestone F: optimize import performance and chart interaction UX

### DIFF
--- a/src/StockKLineApp/Models/ImportProgressInfo.cs
+++ b/src/StockKLineApp/Models/ImportProgressInfo.cs
@@ -1,0 +1,7 @@
+namespace StockKLineApp.Models;
+
+public sealed class ImportProgressInfo
+{
+    public required int Percent { get; init; }
+    public required string Message { get; init; }
+}

--- a/src/StockKLineApp/Services/StockDataCacheService.cs
+++ b/src/StockKLineApp/Services/StockDataCacheService.cs
@@ -1,0 +1,29 @@
+using StockKLineApp.Models;
+
+namespace StockKLineApp.Services;
+
+public sealed class StockDataCacheService
+{
+    private readonly Dictionary<string, IReadOnlyList<DailyBar>> _barsByStock = new(StringComparer.OrdinalIgnoreCase);
+
+    public void ReplaceWith(IReadOnlyList<StockSeries> stocks)
+    {
+        _barsByStock.Clear();
+        foreach (var stock in stocks)
+        {
+            _barsByStock[BuildKey(stock.Code, stock.Name)] = stock.Bars.ToList();
+        }
+    }
+
+    public IReadOnlyList<DailyBar> GetBars(string cacheKey)
+    {
+        if (_barsByStock.TryGetValue(cacheKey, out var bars))
+        {
+            return bars;
+        }
+
+        throw new KeyNotFoundException($"未找到股票缓存数据：{cacheKey}");
+    }
+
+    public static string BuildKey(string code, string name) => $"{code}|{name}";
+}

--- a/src/StockKLineApp/ViewModels/StockListItemViewModel.cs
+++ b/src/StockKLineApp/ViewModels/StockListItemViewModel.cs
@@ -1,5 +1,3 @@
-using StockKLineApp.Models;
-
 namespace StockKLineApp.ViewModels;
 
 public sealed class StockListItemViewModel
@@ -7,7 +5,8 @@ public sealed class StockListItemViewModel
     public required string Code { get; init; }
     public required string Name { get; init; }
     public required string Symbol { get; init; }
-    public required IReadOnlyList<DailyBar> Bars { get; init; }
+    public required string CacheKey { get; init; }
+    public required int BarCount { get; init; }
 
     public string Display => $"{Code} - {Name}";
 }

--- a/src/StockKLineApp/Views/MainWindow.xaml
+++ b/src/StockKLineApp/Views/MainWindow.xaml
@@ -17,7 +17,11 @@
             </TextBox>
         </StackPanel>
 
-        <TextBlock DockPanel.Dock="Top" Margin="0,0,0,12" Text="{Binding StatusMessage}" />
+        <StackPanel DockPanel.Dock="Top" Margin="0,0,0,10">
+            <TextBlock Margin="0,0,0,6" Text="{Binding StatusMessage}" />
+            <ProgressBar Height="14" Minimum="0" Maximum="100" Value="{Binding ImportProgress}" />
+            <TextBlock Margin="0,4,0,0" FontSize="12" Foreground="Gray" Text="{Binding ImportProgressText}" />
+        </StackPanel>
 
         <Grid>
             <Grid.ColumnDefinitions>
@@ -32,6 +36,7 @@
                         <DataGridTextColumn Header="Code" Binding="{Binding Code}" Width="*" />
                         <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="2*" />
                         <DataGridTextColumn Header="Symbol" Binding="{Binding Symbol}" Width="*" />
+                        <DataGridTextColumn Header="K线数量" Binding="{Binding BarCount}" Width="*" />
                         <DataGridTemplateColumn Header="操作" Width="*">
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>
@@ -46,9 +51,21 @@
                 </DataGrid>
             </GroupBox>
 
-            <GroupBox Header="解析错误（已跳过）" Grid.Column="2">
-                <ListBox ItemsSource="{Binding Errors}" />
-            </GroupBox>
+            <Grid Grid.Column="2">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="12"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <GroupBox Header="解析错误（已跳过）" Grid.Row="0">
+                    <ListBox ItemsSource="{Binding Errors}" />
+                </GroupBox>
+
+                <GroupBox Header="日志" Grid.Row="2">
+                    <ListBox ItemsSource="{Binding Logs}" />
+                </GroupBox>
+            </Grid>
         </Grid>
     </DockPanel>
 </Window>

--- a/src/StockKLineApp/Views/MainWindow.xaml.cs
+++ b/src/StockKLineApp/Views/MainWindow.xaml.cs
@@ -1,3 +1,4 @@
+using StockKLineApp.Services;
 using StockKLineApp.ViewModels;
 
 namespace StockKLineApp.Views;
@@ -14,9 +15,9 @@ public partial class MainWindow : System.Windows.Window
         DataContext = viewModel;
     }
 
-    private void NavigateToStockDetail(StockListItemViewModel stock)
+    private void NavigateToStockDetail(StockListItemViewModel stock, StockDataCacheService cache)
     {
-        var detailWindow = new StockDetailWindow(stock)
+        var detailWindow = new StockDetailWindow(stock, cache)
         {
             Owner = this
         };

--- a/src/StockKLineApp/Views/StockDetailWindow.xaml
+++ b/src/StockKLineApp/Views/StockDetailWindow.xaml
@@ -13,6 +13,7 @@
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <TextBlock Text="股票详情" FontSize="20" FontWeight="SemiBold" Margin="0,0,0,16" />
@@ -26,7 +27,7 @@
                    FontSize="13"
                    Margin="0,0,0,8" />
 
-        <StackPanel Grid.Row="6" Orientation="Vertical">
+        <StackPanel Grid.Row="6" Orientation="Vertical" Margin="0,0,0,8">
             <TextBlock Text="时间范围（最近天数）" FontSize="12" Margin="0,0,0,4" />
             <Slider x:Name="RangeSlider"
                     Minimum="0"
@@ -34,5 +35,7 @@
                     IsSnapToTickEnabled="True"
                     ValueChanged="RangeSlider_OnValueChanged" />
         </StackPanel>
+
+        <TextBlock Grid.Row="7" x:Name="RenderCostLabel" FontSize="12" Foreground="Gray" />
     </Grid>
 </Window>


### PR DESCRIPTION
### Motivation
- 提升 CSV 导入与详情页交互的流畅度与可诊断性，满足按股票缓存加载、范围拖动节流、仅渲染可视区等性能要求。 

### Description
- 新增 `StockDataCacheService`，按 `code|name` 缓存每只股票的 `DailyBar` 序列，详情页按缓存键读取数据以避免在页面间传递全量数据。 
- 将 `CsvStockImportService.Import` 扩展为接受 `IProgress<ImportProgressInfo>`，在 `TryImport` 中预先统计行数并每 200 行上报解析进度与消息。 
- 更新 `MainViewModel` 为异步导入 (`OpenCsvAsync`)，显示 `ImportProgress` 与 `ImportProgressText`，新增 `Logs` 面板并将解析错误以日志形式记录。 
- 优化详情页渲染：`StockDetailWindow` 从缓存拉取数据，使用 `DispatcherTimer` 实现 100ms 节流，且每次只构建/渲染当前可视区的 OHLC 数据并显示渲染耗时。 

### Testing
- 尝试使用 `dotnet build StockKLineApp.sln` 进行构建验证，但运行环境缺少 `.NET SDK` 导致命令不可用因此无法完成编译测试。 
- 在仓库中执行了静态文件检查与 basic run-time inspections (文件变更与差异审阅)，并已提交修改。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698883137f2083278665b2a97536199e)